### PR TITLE
Pre-populate stripe forms with user's email

### DIFF
--- a/shell/packages/blackrock-payments/billingPrompt.js
+++ b/shell/packages/blackrock-payments/billingPrompt.js
@@ -162,7 +162,8 @@ var helpers = {
       amount: this.price,
       panelLabel: "{{amount}} / Month",
       id: Template.instance().id,
-      planName: this._id
+      planName: this._id,
+      email: Meteor.user().profile.email
     });
   },
   plans: function () {

--- a/shell/packages/blackrock-payments/billingSettings.js
+++ b/shell/packages/blackrock-payments/billingSettings.js
@@ -108,7 +108,7 @@ Template.billingSettings.helpers({
     return JSON.stringify({
       name: 'Sandstorm Oasis',
       panelLabel: "Add Card",
-      email: data.email,
+      email: Meteor.user().profile.email,
       id: template.id
     });
   },


### PR DESCRIPTION
We are now guaranteed to have an email in user.profile, so this will
always be pre-populated
