### PR TITLE
Update obsolete uses of user.profile.email.

### DIFF
--- a/shell/packages/blackrock-payments/billingPrompt.js
+++ b/shell/packages/blackrock-payments/billingPrompt.js
@@ -186,6 +186,8 @@ var helpers = {
   },
   checkoutData: function () {
     var title = this._id.charAt(0).toUpperCase() + this._id.slice(1);
+    var primaryEmail = _.findWhere(SandstormDb.getUserEmails(Meteor.user()), {primary: true});
+    if (!primaryEmail) return;
 
     // Firefox will apparently automatically do some URI encoding if we don't do it ourselves.
     // Other browsers won't. Meanwhile Firefox used to also do some automatic decoding on the
@@ -197,7 +199,7 @@ var helpers = {
       panelLabel: "{{amount}} / Month",
       id: Template.instance().id,
       planName: this._id,
-      email: Meteor.user().profile.email
+      email: primaryEmail.email,
     }));
   },
   plans: function () {

--- a/shell/packages/blackrock-payments/billingSettings.js
+++ b/shell/packages/blackrock-payments/billingSettings.js
@@ -108,10 +108,12 @@ Template.billingSettings.helpers({
     var template = Template.instance();
     var data = StripeCustomerData.findOne();
     if (!data) return;
+    var primaryEmail = _.findWhere(SandstormDb.getUserEmails(Meteor.user()), {primary: true});
+    if (!primaryEmail) return;
     return encodeURIComponent(JSON.stringify({
       name: 'Sandstorm Oasis',
       panelLabel: "Add Card",
-      email: Meteor.user().profile.email,
+      email: primaryEmail.email,
       id: template.id
     }));
   },


### PR DESCRIPTION
This is dependent on https://github.com/sandstorm-io/sandstorm/pull/1015
(The idea is that this should be the only change I need to make to the blackrock code; further evolution of user accounts should still support the getUserEmails() interface.)

Fixes #10.
