### PR TITLE
Depend on shell-env, not just deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 	make -f deps/sandstorm/Makefile clean
 	find shell/packages -type l | xargs -r rm
 
-continuous: tmp/.deps
+continuous: shell-env
 	make -f deps/sandstorm/Makefile continuous
 
 # These rules generate shell/.meteor by copying over files from Sandstorm and


### PR DESCRIPTION
This allows `make continuous` to be the first thing you run in a fresh checkout.

Otherwise, as @dwrensha experienced, none of the files in `shell/.meteor` would get created.
