### PR TITLE
Calculate visual width of storage progress bar correctly

### DIFF
--- a/shell/packages/blackrock-payments/billingPrompt.html
+++ b/shell/packages/blackrock-payments/billingPrompt.html
@@ -201,7 +201,7 @@ limitations under the License.
           <td>Storage</td>
           <td>
             <div class="progress-bar">
-              <div style="width: {{renderPercent used.storage}}%"></div>
+              <div style="width: {{renderPercent used.storage plan.storage referralBonus.storage}}%"></div>
             </div>
             <div class="used"><span class="amount">{{renderStoragePrecise used.storage}}</span> used</div>
             <div class="total"><span class="amount">{{renderStorage plan.storage referralBonus.storage}}</span> total</div>

--- a/shell/packages/blackrock-payments/billingPrompt.js
+++ b/shell/packages/blackrock-payments/billingPrompt.js
@@ -264,7 +264,10 @@ var helpers = {
     }
     return (quantity === Infinity) ? "unlimited" : quantity.toString();
   },
-  renderPercent: function (num, denom) {
+  renderPercent: function (num, denom, additionalDenom) {
+    if (typeof additionalDenom === "number") {
+      denom += additionalDenom;
+    }
     return Math.min(100, Math.max(0, num / denom * 100)).toPrecision(3);
   },
   isSelecting: function () {


### PR DESCRIPTION
Thanks @dwrensha for noticing this bug.

I actually had noticed it in my dev environment too but thought it was an environment issue, not a code bug. But a code bug it definitely is. Fixed now.

@kentonv ready for your merge/review.
