### PR TITLE
Support 'hidden' plans, which are discontinued.

### DIFF
--- a/shell/packages/blackrock-payments/billingPrompt.html
+++ b/shell/packages/blackrock-payments/billingPrompt.html
@@ -53,7 +53,7 @@ limitations under the License.
   {{#if isComplete}}
     <h2>Success!</h2>
     <p class="success-note">You've changed your plan from <strong>{{oldPlan}}</strong> to
-      <strong>{{myPlan._id}}</strong>.</p>
+      <strong>{{planTitle myPlan}}</strong>.</p>
     <button class="continue">Continue</button>
   {{else}}
 
@@ -109,7 +109,7 @@ limitations under the License.
   <div class="first-time-billing-prompt">
     {{#if planChosen}}
       <h2>Success!</h2>
-      <p class="success-note">You've selected <strong>{{myPlan._id}}</strong>.</p>
+      <p class="success-note">You've selected <strong>{{planTitle myPlan}}</strong>.</p>
       <button class="continue">Continue</button>
     {{else}}
       <h2>Choose a Plan</h2>
@@ -135,7 +135,7 @@ limitations under the License.
 
         <p>{{#if isCurrent}}Current Plan{{else}}&nbsp;{{/if}}</p>
         <table>
-          <tr><td>{{_id}}</td></tr>
+          <tr><td>{{planTitle .}}</td></tr>
           <tr><td>
             {{#if price}}
               <p>${{renderDollars price}}</p>
@@ -253,7 +253,7 @@ limitations under the License.
           </span>
         </p>
       {{/if}}
-      <p>Based on current plan: <span class="plan-name">{{plan._id}}</span>
+      <p>Based on current plan: <span class="plan-name">{{planTitle plan}}</span>
         <button class="change-plan">change plan</button></p>
     {{/if}}{{/with}}
   </div>

--- a/shell/packages/blackrock-payments/payments-server.js
+++ b/shell/packages/blackrock-payments/payments-server.js
@@ -185,6 +185,10 @@ var methods = {
 
     var planInfo = this.connection.sandstormDb.getPlan(newPlan);
 
+    if (planInfo.hidden) {
+      throw new Meteor.Error(403, "Can't choose discontinued plan.");
+    }
+
     var payments = Meteor.user().payments;
     if (payments) {
       var customerId = payments.id;


### PR DESCRIPTION
A user can stay on a hidden plan as long as they want, but once they switch, they can't switch back. (We'll be discontinuing "Standard" and "Large" plans, replacing them with the new $9 "Basic" plan.)

This change also adds support for assigning plans a title that is different from the plan ID, so that we can rename plans. (We'll be renaming "Mega" to "Power User".)

This change depends on Sandstorm commit e9e1272: https://github.com/sandstorm-io/sandstorm/commit/e9e1272ab5199d3ef145672f29f28589071f889d
