### PR TITLE
Add missing 'event' parameter.

### DIFF
--- a/shell/packages/blackrock-payments/billingPrompt.js
+++ b/shell/packages/blackrock-payments/billingPrompt.js
@@ -155,7 +155,7 @@ Template.billingUsage.events({
 });
 
 Template.mailingListBonusNotificationButtons.events({
-  "click .accept-notification": function () {
+  "click .accept-notification": function (event) {
     event.preventDefault();
     Meteor.call("subscribeMailingList", function(err) {
       if (err) window.alert("Error subscribing to list: " + err.message);


### PR DESCRIPTION
Someone on IRC reported that the "Subscribe" button was not working on Firefox. I believe this fixes the problem, but I have not tested it.
