### PR TITLE
Move mailinglist bonus notification template to Sandstorm shell

### DIFF
--- a/shell/packages/blackrock-payments/billingPrompt.html
+++ b/shell/packages/blackrock-payments/billingPrompt.html
@@ -321,13 +321,3 @@ All Rights Reserved
     {{/if}}
   {{/if}}
 </template>
-
-<template name="mailingListBonusNotification">
-  Subscribe to our announcement list and get <strong>{{renderStorage MAILING_LIST_BONUS}} bonus
-  storage</strong> (1-2 emails per month).
-</template>
-
-<template name="mailingListBonusNotificationButtons">
-  <button class="cancel-notification">No thanks</button>
-  <button class="accept-notification">Subscribe</button>
-</template>

--- a/shell/packages/blackrock-payments/billingPrompt.js
+++ b/shell/packages/blackrock-payments/billingPrompt.js
@@ -154,16 +154,6 @@ Template.billingUsage.events({
   },
 });
 
-Template.mailingListBonusNotificationButtons.events({
-  "click .accept-notification": function (event) {
-    event.preventDefault();
-    Meteor.call("subscribeMailingList", function(err) {
-      if (err) window.alert("Error subscribing to list: " + err.message);
-    });
-    Meteor.call("dismissNotification", this._id);
-  },
-});
-
 function clickPlanHelper(context, ev) {
   var template = Template.instance();
   var planName = context._id;
@@ -401,4 +391,3 @@ Template._billingPromptPopup.helpers(helpers);
 Template.billingUsage.helpers(helpers);
 Template.billingPromptFirstTime.helpers(helpers);
 Template.billingOptins.helpers(helpers);
-Template.mailingListBonusNotification.helpers(helpers);

--- a/shell/packages/blackrock-payments/payments-client.js
+++ b/shell/packages/blackrock-payments/payments-client.js
@@ -40,6 +40,8 @@ BlackrockPayments.processOptins = function (form) {
   }
 };
 
+BlackrockPayments.MAILING_LIST_BONUS = MAILING_LIST_BONUS;
+
 // Client-side method simulations.
 Meteor.methods({
   unsubscribeMailingList: function () {


### PR DESCRIPTION
I'm doing some refactoring of the notifications code/styles, and this
feels like it makes sense.  The referral program notifications also
live in Sandstorm proper, so this seems reasonable.

Depends on/complements https://github.com/sandstorm-io/sandstorm/pull/2328.
