### PR TITLE
Fix "Unsubscribe" button on accounts page in Firefox.

### DIFF
--- a/shell/packages/blackrock-payments/billingPrompt.js
+++ b/shell/packages/blackrock-payments/billingPrompt.js
@@ -4,27 +4,27 @@
 
 var idCounter = 0;
 
-var messageListener = function (template, event) {
-  if (event.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {
+var messageListener = function (template, ev) {
+  if (ev.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {
     return;
   }
 
-  if (event.data.id !== template.id) {
+  if (ev.data.id !== template.id) {
     return;
   }
 
-  if (event.data.showPrompt) {
-    template.promptChoice.set(event.data.plan);
+  if (ev.data.showPrompt) {
+    template.promptChoice.set(ev.data.plan);
     return;
   }
 
-  if (event.data.token) {
+  if (ev.data.token) {
     var updateData = {
-      email: event.data.token.email,
-      subscription: event.data.plan
+      email: ev.data.token.email,
+      subscription: ev.data.plan
     };
-    Meteor.call("createUserSubscription", event.data.token.id,
-                event.data.token.email, event.data.plan, function (err, source) {
+    Meteor.call("createUserSubscription", ev.data.token.id,
+                ev.data.token.email, ev.data.plan, function (err, source) {
       if (err) {
         alert(err); // TODO(soon): make this UI better);
         return;
@@ -40,7 +40,7 @@ var messageListener = function (template, event) {
     });
   }
 
-  if (event.data.error || event.data.token) {
+  if (ev.data.error || ev.data.token) {
     template.promptChoice.set(null);
   }
 };
@@ -134,20 +134,20 @@ Template.billingUsage.helpers({
 });
 
 Template.billingUsage.events({
-  "click .change-plan": function (event, template) {
-    event.preventDefault();
+  "click .change-plan": function (ev, template) {
+    ev.preventDefault();
     template._showPrompt.set(true);
   },
 
-  "click .unsubscribe": function () {
-    event.preventDefault();
+  "click .unsubscribe": function (ev) {
+    ev.preventDefault();
     Meteor.call("unsubscribeMailingList", function(err) {
       if (err) window.alert("Error unsubscribing from list: " + err.message);
     });
   },
 
-  "click .subscribe": function () {
-    event.preventDefault();
+  "click .subscribe": function (ev) {
+    ev.preventDefault();
     Meteor.call("subscribeMailingList", function(err) {
       if (err) window.alert("Error subscribing to list: " + err.message);
     });

--- a/shell/packages/blackrock-payments/billingSettings.js
+++ b/shell/packages/blackrock-payments/billingSettings.js
@@ -2,29 +2,29 @@
 // Copyright (c) 2015-2016 Sandstorm Development Group, Inc.
 // All Rights Reserved
 
-var messageListener = function (showPrompt, template, event) {
-  if (event.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {
+var messageListener = function (showPrompt, template, ev) {
+  if (ev.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {
     return;
   }
 
-  if (event.data.id !== template.id) {
+  if (ev.data.id !== template.id) {
     return;
   }
 
-  if (event.data.showPrompt) {
+  if (ev.data.showPrompt) {
     showPrompt.set(true);
     return;
   }
 
-  if (event.data.token) {
-    Meteor.call("addCardForUser", event.data.token.id, event.data.token.email, function (err) {
+  if (ev.data.token) {
+    Meteor.call("addCardForUser", ev.data.token.id, ev.data.token.email, function (err) {
       if (err) alert(err); // TODO(soon): make this UI better
 
       updateStripeData();
     });
   }
 
-  if (event.data.error || event.data.token) {
+  if (ev.data.error || ev.data.token) {
     showPrompt.set(false);
   }
 };

--- a/shell/packages/blackrock-payments/payments-api-client.js
+++ b/shell/packages/blackrock-payments/payments-api-client.js
@@ -3,14 +3,14 @@
 // All Rights Reserved
 
 Template.stripePaymentAcceptorPowerboxConfiguration.events({
-  "submit form"(event) {
-    event.preventDefault();
+  "submit form"(ev) {
+    ev.preventDefault();
 
     this.powerboxRequest.completeNewFrontendRef({
       stripePaymentAcceptor: {
-        acceptorTitle: event.currentTarget.acceptorTitle.value,
-        returnAddress: event.currentTarget.returnAddress.value,
-        settingsUrl: event.currentTarget.settingsUrl.value,
+        acceptorTitle: ev.currentTarget.acceptorTitle.value,
+        returnAddress: ev.currentTarget.returnAddress.value,
+        settingsUrl: ev.currentTarget.settingsUrl.value,
       },
     });
   }
@@ -27,23 +27,23 @@ Template.stripeAddPaymentSourcePowerboxConfiguration.onCreated(function () {
   updateStripeData();
   this.addCardPrompt = new ReactiveVar(false);
   this.id = "stripe-powerbox-add-card-" + (counter++);
-  this.listener = event => {
-    console.log(event);
-    if (event.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {
+  this.listener = ev => {
+    console.log(ev);
+    if (ev.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {
       return;
     }
 
-    if (event.data.id !== this.id) {
+    if (ev.data.id !== this.id) {
       return;
     }
 
-    if (event.data.showPrompt) {
+    if (ev.data.showPrompt) {
       // ignore
       return;
     }
 
-    if (event.data.token) {
-      Meteor.call("addCardForUser", event.data.token.id, event.data.token.email, (err, source) => {
+    if (ev.data.token) {
+      Meteor.call("addCardForUser", ev.data.token.id, ev.data.token.email, (err, source) => {
         if (err) {
           this.data.powerboxRequest.failRequest(err);
         } else {
@@ -56,7 +56,7 @@ Template.stripeAddPaymentSourcePowerboxConfiguration.onCreated(function () {
       });
     }
 
-    if (event.data.error) {
+    if (ev.data.error) {
       this.data.powerboxRequest.cancelRequest();
     }
   };


### PR DESCRIPTION
Or a less-sensational title that explains the rest of the changeset: avoid
using the global "event" and avoid using "event" as a variable name.

Some browser environments define a global "event" which is set to the current
event that is being dispatched for the duration of event dispatch.  Other
browsers do not.

As a result, since a variable named "event" may or may not shadow the global
event object, it's best to avoid the whole confusion and never name a variable
"event" or use a reference named "event". [1]

[1] - http://eslint.org/docs/rules/no-restricted-globals
