### PR TITLE
Fix embedded image in invoice emails

### DIFF
--- a/shell/packages/blackrock-payments/payments-server.js
+++ b/shell/packages/blackrock-payments/payments-server.js
@@ -185,7 +185,7 @@ function sendEmail(db, user, mailSubject, mailText, mailHtml, config) {
       attachments: [
         {
           filename: "sandstorm-logo.png",
-          contents: ICON_BASE64,
+          content: ICON_BASE64,
           contentType: "image/png",
           cid: iconCid
         },


### PR DESCRIPTION
nodemailer expects the parameter "content", not "contents", so when we provided the attachment, it thought we gave it an empty content.
