### PR TITLE
Enable nodejs perf maps

### DIFF
--- a/src/blackrock/frontend.c++
+++ b/src/blackrock/frontend.c++
@@ -1014,7 +1014,7 @@ kj::Promise<void> FrontendImpl::execLoop(MongoInfo&& mongoInfo, uint replicaNumb
       KJ_SYSCALL(dup2(http, 4));
 
       // Execute!
-      KJ_SYSCALL(execl("bin/node", "bin/node", "sandstorm-main.js", (char*)nullptr));
+      KJ_SYSCALL(execl("bin/node", "bin/node", "--perf_basic_prof_only_functions", "sandstorm-main.js", (char*)nullptr));
       KJ_UNREACHABLE;
     });
 


### PR DESCRIPTION
This will cause node to create a perf map file at `/tmp/perf-${PID}.map`, which
the suite of perf tools can use to map runtime heap addresses to JIT-compiled
symbols.

This file is expected to grow at a rate of around 1MB/hour [1], which I think is totally acceptable
given that we do weekly Oasis releases, so the file will likely never grow beyond 168MB or thereabouts.  If third parties are imminently likely to run blackrock, file size here may become a consideration, and we can either make this an option or just revert.

Enabling this flag does not significantly impact runtime performance.  Netflix runs their code with this flag enabled in production, and I think Uber does too [2].

[1] - https://yunong.io/2015/11/23/generating-node-js-flame-graphs/
[2] - https://bugs.chromium.org/p/v8/issues/detail?id=3453
