### PR TITLE
make quotaEnabled as part of config.capnp

### DIFF
--- a/src/blackrock/frontend.c++
+++ b/src/blackrock/frontend.c++
@@ -1017,7 +1017,7 @@ kj::Promise<void> FrontendImpl::execLoop(MongoInfo&& mongoInfo, uint replicaNumb
           ", \"isTesting\":", config.getIsTesting() ? "true" : "false",
           ", \"hideTroubleshooting\": true",
           ", \"wildcardHost\":\"", config.getWildcardHost(), "\""
-          ", \"quotaEnabled\": true"
+          ", \"quotaEnabled\":", config.getIsQuotaEnabled() ? "true" : "false",
           ", \"stripePublicKey\":\"", config.getStripePublicKey(), "\""
           ", \"outOfBeta\": ", config.getOutOfBeta() ? "true" : "false",
           ", \"allowUninvited\":", config.getAllowUninvited() ? "true" : "false",

--- a/src/blackrock/frontend.capnp
+++ b/src/blackrock/frontend.capnp
@@ -56,6 +56,8 @@ struct FrontendConfig {
   isTesting @5 :Bool;
   # Equivalent to IS_TESTING from sandstorm.conf.
 
+  isQuotaEnabled @13 :Bool;
+
   stripeKey @6 :Text;
   stripePublicKey @7 :Text;
   outOfBeta @12 :Bool;

--- a/src/blackrock/frontend.capnp
+++ b/src/blackrock/frontend.capnp
@@ -56,7 +56,7 @@ struct FrontendConfig {
   isTesting @5 :Bool;
   # Equivalent to IS_TESTING from sandstorm.conf.
 
-  isQuotaEnabled @13 :Bool;
+  isQuotaEnabled @13 :Bool = true;
 
   stripeKey @6 :Text;
   stripePublicKey @7 :Text;

--- a/test-config.capnp
+++ b/test-config.capnp
@@ -10,7 +10,6 @@ const vagrant :MasterConfig = (
     wildcardHost = "*.localrock.sandstorm.io:6080",
     allowDemoAccounts = true,
     isTesting = true,
-    isQuotaEnabled = false,
 #    stripeKey = "sk_test_???",
 #    stripePublicKey = "pk_test_???",
     outOfBeta = true,

--- a/test-config.capnp
+++ b/test-config.capnp
@@ -10,6 +10,7 @@ const vagrant :MasterConfig = (
     wildcardHost = "*.localrock.sandstorm.io:6080",
     allowDemoAccounts = true,
     isTesting = true,
+    isQuotaEnabled = false,
 #    stripeKey = "sk_test_???",
 #    stripePublicKey = "pk_test_???",
     outOfBeta = true,


### PR DESCRIPTION
Workaround for turn off billing module (in this [discussion](https://groups.google.com/forum/#!topic/sandstorm-dev/LwKYz5oX3nw))
Need have a plan option named 'free', or user will get 'No such plan free' Error
And we can simply turn-off quotaEnabled setting to skip the step of check plans
However, quotaEnabled is hard code in frontend.c++

So, I modify parts of code to let quotaEnabled setting as a part of config file 
